### PR TITLE
(PUP-6483) Return false for nil passwords in Windows user provider

### DIFF
--- a/lib/puppet/provider/user/windows_adsi.rb
+++ b/lib/puppet/provider/user/windows_adsi.rb
@@ -124,7 +124,11 @@ Puppet::Type.type(:user).provide :windows_adsi do
   end
 
   def password=(value)
-    # TODO: emit Puppet debug message here about setting a property that we can't verify when this is nil or ''
+    if value.nil?
+      Puppet.warning("Puppet does not support setting a nil password on Windows.")
+    elsif value == ''
+      Puppet.warning("Blank (zero length) passwords are not recommended. Blank passwords may be allowed on your system based on policy, but Puppet cannot verify a blank password with the operating system. Because of this a password change event will be executed by Puppet on every run.")
+    end
     user.password = value
   end
 

--- a/lib/puppet/util/windows/user.rb
+++ b/lib/puppet/util/windows/user.rb
@@ -56,12 +56,9 @@ module Puppet::Util::Windows::User
     # Logon failure: user account restriction. Possible reasons are blank passwords
     # not allowed, logon hour restrictions, or a policy restriction has been enforced.
     if password.nil? || password == ''
-      raise Puppet::Util::Windows::Error.new(
-        "Windows does not have the ability to verify NULL or empty passwords"
-      )
+      Puppet.warning("Windows does not have the ability to verify NULL or empty passwords")
+      return false
     end
-    # TODO: maybe do this instead? -  return false if password.nil? || password == ''
-
     begin
       logon_user(name, password) { |token| }
     rescue Puppet::Util::Windows::Error

--- a/spec/integration/util/windows/user_spec.rb
+++ b/spec/integration/util/windows/user_spec.rb
@@ -106,8 +106,13 @@ describe "Puppet::Util::Windows::User", :if => Puppet.features.microsoft_windows
         expect(Puppet::Util::Windows::User.password_is?(username, bad_password)).to be_falsey
       end
 
-      it "should raise an error given a nil password" do
-        expect { Puppet::Util::Windows::User.password_is?(username, nil) }.to raise_error(Puppet::Util::Windows::Error)
+      it "should return false given a nil password" do
+        expect(Puppet::Util::Windows::User.password_is?(username, nil)).to be_falsey
+      end
+
+      it "should warn that empty/nil passwords cannot be verified given a nil password" do
+        Puppet::Util::Windows::User.password_is?(username, nil)
+        expect(@logs).to have_matching_log(/does not have the ability to verify NULL or empty passwords/)
       end
 
       it "should return false given a nil username and an incorrect password" do

--- a/spec/unit/provider/user/windows_adsi_spec.rb
+++ b/spec/unit/provider/user/windows_adsi_spec.rb
@@ -26,13 +26,22 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
       stub_users = names.map{|n| stub(:name => n)}
       connection.stubs(:execquery).with('select name from win32_useraccount where localaccount = "TRUE"').returns(stub_users)
 
-      #TODO: should never call logon_user
       expect(described_class.instances.map(&:name)).to match(names)
     end
   end
 
   it "should provide access to a Puppet::Util::Windows::ADSI::User object" do
     expect(provider.user).to be_a(Puppet::Util::Windows::ADSI::User)
+  end
+
+  describe "when retrieving the password property" do
+    context "when the resource has a nil password" do
+      it "should never issue a logon attempt" do
+        resource.stubs(:[]).with(any_of(:name, :password)).returns(nil)
+        Puppet::Util::Windows::User.expects(:logon_user).never
+        provider.password
+      end
+    end
   end
 
   describe "when managing groups" do
@@ -228,18 +237,18 @@ describe Puppet::Type.type(:user).provider(:windows_adsi), :if => Puppet.feature
     end
 
     it "should generate a warning with an empty password" do
-      resource[:password] = ''
-
-      # expect
+      provider.user.expects(:password=).with('')
+      provider.password = ''
+      expect(@logs).to have_matching_log(/Puppet cannot verify a blank password with the operating system/)
     end
 
     it "should generate a warning with a nil password" do
       # TODO: can we use error code 1327 to identify that a user in fact has an empty password
       # i.e. is the error code returned when logging in unsuccessfully with a valid empty password
       # any different than trying to login with an invalid non-empty password?
-      resource[:password] = ''
-
-      # expect
+      provider.user.expects(:password=).with(nil)
+      provider.password = nil
+      expect(@logs).to have_matching_log(/Puppet does not support setting a nil password on Windows/)
     end
 
     it 'should not create a user if a group by the same name exists' do


### PR DESCRIPTION
This commit builds on a previous commit by Iristyle for PUP-6483 in which
running `puppet resource user` caused login attempts a Windows sytem for each
user.

For property value retrieval, Puppet calls the getter for each property
for each resource. Previously, the password getter would ultimately call
logonUserW even with an empty/nil password. Because Windows does not allow
blank passwords, this would throw, get rescued, and return false, eventually
surfacing as a nil return value from the getter, with the side-effect of having
issued a failed logon attempt. Now the getter will return nil before issuing
the logon attempt if asked to validate an empty/nil password - it will
explicitly skip calling logonUser for password validation.

Since the password query should no longer issue a logon attempt if the password
property is nil for the resource, we add a test for this. This doesn't actually
go into the self.instances block just because self.instances actually doesn't
result in any calls to the password getter - that's done separately when
retrieving values for all properties for each provider instance.

A quick note - the previous implementation of a fix raised an exception if the
password_is? function was passed an empty or nil password. This commit modifies
this to return false and issue a warning to keep with the previous behavior
which was to return false.

New warnings are issued by the provider if a password setting attempt is made
with a nil value or empty string. They are different because as of PUP-5271 it
has not been supported to set a nil password - such an attempt is silently
ignored by Puppet::Util::Windows::ADSI::User#password=. This commit adds a new
warning for that case, as well as a recommendation not to set blank passwords.